### PR TITLE
Change "Get Id From Label In Modal Form" to "Get Element From Label"

### DIFF
--- a/resources/EmissionFactor.resource
+++ b/resources/EmissionFactor.resource
@@ -93,16 +93,15 @@ Generic Emission Factor Form
     FOR  ${label}  IN  @{others}
         VAR    ${value}    ${others}[${label}]
         IF  $value == 'SKIP'    CONTINUE
-        ${input id}    Get Id From Label In Modal Form    ${label}
-        ${strategy}    Check Input Type    id:${input id}
+        ${element}    Get Element From Label    ${label}
+        ${strategy}    Check Input Type    ${element}
         IF  $strategy == 'TF'
-            IF  $value is not None    Input Text    id:${input id}    ${value}
+            IF  $value is not None    Input Text    ${element}    ${value}
         ELSE IF  $strategy == 'DD'
-            Select Drop Down By Locator    id:${input id}    ${value}
+            Select Drop Down By Locator    ${element}    ${value}
         ELSE  # CB
             IF  $value is not None
-                ${checkbox}    Get WebElement    id:${input id}
-                IF  $checkbox.is_selected() != $value    Click Element    ${checkbox}
+                IF  $element.is_selected() != $value    Click Element    ${element}
             END
         END
     END
@@ -113,8 +112,8 @@ Generic Emission Factor Form
 
     FOR  ${gas}  IN  @{gases}
         VAR    ${value}    ${gases}[${gas}]
-        ${input id}    Get Id From Label In Modal Form    ${gas}    compare=.
-        IF    $value != 'SKIP' and $value is not None    Input Text    id:${input id}    ${value}
+        ${element}    Get Element From Label    ${gas}    compare=.
+        IF    $value != 'SKIP' and $value is not None    Input Text    ${element}    ${value}
     END
 
 Enter Energy Emission Factor Form
@@ -130,8 +129,7 @@ Enter Energy Emission Factor Form
     ...    ${filling method}=${None}
     ...    &{gases}
 
-    ${group}    Get Id From Label In Modal Form    Emission Group
-    ${element}    Get WebElement    id:${group}
+    ${element}    Get Element From Label    Emission Group
     VAR    ${emission group}    ${{'Energy' if $element.is_enabled() else 'SKIP'}}
 
     Generic Emission Factor Form
@@ -159,8 +157,7 @@ Enter Fuel Emission Factor Form
     ...    ${filling method}=${None}
     ...    &{gases}
 
-    ${group}    Get Id From Label In Modal Form    Emission Group
-    ${element}    Get WebElement    id:${group}
+    ${element}    Get Element From Label    Emission Group
     VAR    ${emission group}    ${{'Fuel' if $element.is_enabled() else 'SKIP'}}
 
     Generic Emission Factor Form
@@ -187,8 +184,7 @@ Enter Purchases Emission Factor Form
     ...    ${filling method}=${None}
     ...    &{gases}
 
-    ${group}    Get Id From Label In Modal Form    Emission Group
-    ${element}    Get WebElement    id:${group}
+    ${element}    Get Element From Label    Emission Group
     VAR    ${emission group}    ${{'Purchases' if $element.is_enabled() else 'SKIP'}}
 
     Generic Emission Factor Form

--- a/resources/FormUtility.resource
+++ b/resources/FormUtility.resource
@@ -58,13 +58,15 @@ Check Input Type
     IF  'mantine-MultiSelect-inputField' in $class  RETURN  MS
     RETURN    TF
 
-Get Id From Label In Modal Form
-    [Documentation]    คืน id ของ input จาก label ที่มี ``text`` ที่ได้รับมา
-    ...    และ ``compare`` คือสิ่งที่จะเอามาเทียบกับ ``text``
-    [Arguments]    ${text}    ${compare}=text()
-    VAR    ${xpath}    (//label[(contains(@class, 'InputWrapper-label') or contains(@class, 'Checkbox-label')) and ./descendant-or-self::*[${compare}='${text}']])[last()]
-    ${input id}    Get Element Attribute    ${xpath}    for
-    RETURN    ${input id}
+Get Element From Label
+    [Documentation]
+    ...    คืน WebElement ที่ id ตรงกับ for attribute ของ label ที่มีข้อความ ``label``
+    ...
+    ...    ``compare`` เป็นวิธีในการหาข้อความ ``label``
+    [Arguments]    ${label}    ${compare}=text()
+    VAR    ${label_for}    (//label[./descendant-or-self::*[${compare}='${label}']]/@for)[last()]
+    ${element}    Get WebElement    //*[@id=${label_for}]
+    RETURN    ${element}
 
 Select Date
     [Documentation]    เลือกเดือนและปีในปฏิทินตาม ``month year`` ด้วยรูปแบบเดือนเว้นวรรคปี เช่น ``Oct 2002``
@@ -144,9 +146,9 @@ Select Drop Down
     ...    | Select Drop Down | Organization | Zpliporn Test | # เลือก org เป็น Zpliporn Test |
     ...    | Select Drop Down | Site         | Building 1    | # เลือก site เป็น Building 1   |
     [Arguments]    ${label}    ${option}=${None}
-    ${drop down}    Get Id From Label In Modal Form    ${label}
-    Scroll Element Into View       id:${drop down}
-    Select Drop Down By Locator    id:${drop down}    ${option}
+    ${drop down}    Get Element From Label    ${label}
+    Scroll Element Into View       ${drop down}
+    Select Drop Down By Locator    ${drop down}    ${option}
 
 Select Drop Down By Locator
     [Documentation]
@@ -351,8 +353,8 @@ Click Close Modal
 Drop Down Should Not Contain Option
     [Documentation]    ตรวจสอบว่า drop down ``label`` ไม่มี ``option``
     [Arguments]    ${label}    ${option}
-    ${input}    Get Id From Label In Modal Form    ${label}
-    Scroll Element Into View    id:${input}
-    Click Element    id:${input}
+    ${input}    Get Element From Label    ${label}
+    Scroll Element Into View    ${input}
+    Click Element    ${input}
     Element Should Not Be Visible    ${POPOVER_XPATH}//span[text()='${option}']
     ...    message=There is '${option}' option in ${label}.

--- a/resources/ReportTemplate.resource
+++ b/resources/ReportTemplate.resource
@@ -35,8 +35,8 @@ Add Report Template
     Wait Until Element Is Visible    //section//button[.//span[text()='Next']]
     
     Select Drop Down    Reporting Organization    ${report org}
-    ${input id}    Get Id From Label In Modal Form    Organizations To Be Included In Report
-    MultiSelect Drop Down By Locator    id:${input id}    @{include org}
+    ${input}    Get Element From Label    Organizations To Be Included In Report
+    MultiSelect Drop Down By Locator    ${input}    @{include org}
 
     Click Button    //section//button[.//span[text()='Next']]
     
@@ -60,8 +60,8 @@ Enter Report Details
     ...    ${from base period}=${None}    ${to base period}=${None}
     
     IF  $include_org is not None
-        ${input id}    Get Id From Label In Modal Form    Organizations To Be Included In Report
-        MultiSelect Drop Down By Locator    id:${input id}    @{include org}
+        ${input}    Get Element From Label    Organizations To Be Included In Report
+        MultiSelect Drop Down By Locator    ${input}    @{include org}
     END
 
     IF  $report_name
@@ -74,17 +74,17 @@ Enter Report Details
         VAR    ${to base period}    ${from base period}
     END
     IF  $from_period is not None
-        ${input id}    Get Id From Label In Modal Form    Report Period
-        Wait Until Element Is Visible    id:${input id}
-        Click Element    id:${input id}
+        ${input}    Get Element From Label    Report Period
+        Wait Until Element Is Visible    ${input}
+        Click Element    ${input}
         Select Date    ${from period}
         Select Date    ${to period}
         Wait Until Element Is Not Visible    ${POPOVER_XPATH}
     END
     IF  $from_base_period is not None
-        ${input id}    Get Id From Label In Modal Form    Base Year Period
-        Wait Until Element Is Visible    id:${input id}
-        Click Element    id:${input id}
+        ${input}    Get Element From Label    Base Year Period
+        Wait Until Element Is Visible    ${input}
+        Click Element    ${input}
         Select Date    ${from base period}
         Select Date    ${to base period}
         Wait Until Element Is Not Visible    ${POPOVER_XPATH}
@@ -100,9 +100,9 @@ Enter FR-01
         Input Text    name:detail.creatorName    ${creator}
     END
     IF  $report_date is not None
-        ${input id}    Get Id From Label In Modal Form    Report Date
-        Scroll Element Into View    id:${input id}
-        Click Element    id:${input id}
+        ${input}    Get Element From Label    Report Date
+        Scroll Element Into View    ${input}
+        Click Element    ${input}
         Select Exact Date    ${report date}
         Wait Until Element Is Not Visible    ${POPOVER_XPATH}
     END


### PR DESCRIPTION
## Old vs New
โค้ดเดิม
```
Get Id From Label In Modal Form
    [Documentation]    คืน id ของ input จาก label ที่มี ``text`` ที่ได้รับมา
    ...    และ ``compare`` คือสิ่งที่จะเอามาเทียบกับ ``text``
    [Arguments]    ${text}    ${compare}=text()
    VAR    ${xpath}    (//label[(contains(@class, 'InputWrapper-label') or contains(@class, 'Checkbox-label')) and ./descendant-or-self::*[${compare}='${text}']])[last()]
    ${input id}    Get Element Attribute    ${xpath}    for
    RETURN    ${input id}
```
โค้ดใหม่
```
Get Element From Label
    [Documentation]
    ...    คืน WebElement ที่ id ตรงกับ for attribute ของ label ที่มีข้อความ ``label``
    ...
    ...    ``compare`` เป็นวิธีในการหาข้อความ ``label``
    [Arguments]    ${label}    ${compare}=text()
    VAR    ${label_for}    (//label[./descendant-or-self::*[${compare}='${label}']]/@for)[last()]
    ${element}    Get WebElement    //*[@id=${label_for}]
    RETURN    ${element}
```
## สิ่งที่เปลี่ยนไป
### 1. แก้ไข xpath ให้กระชับขึ้น
xpath ที่ใช้ในการหา label ของเดิมคือ `//label[(contains(@class, 'InputWrapper-label') or contains(@class, 'Checkbox-label')) and ./descendant-or-self::*[${compare}='${text}']]` จะแก้ไขโดยการนำ `(contains(@class, 'InputWrapper-label') or contains(@class, 'Checkbox-label'))` ออกไปเพราะไม่มีความจำเป็นต้องหา label จาก class ซึ่งจะทำให้ xpath เหลือเพียงแค่
**`//label[./descendant-or-self::*[${compare}='${label}']]`**

จากนั้นเราต้องการหาเฉพาะ label ที่มี attribute for จึงเพิ่ม `/@for` ต่อหลังเข้าไป นอกจากนี้การเพิ่ม `/@for` จะทำให้สามารถนำค่าของ for เอาไปใช้ในการหา element อื่นต่อได้ (สิ่งที่เปลี่ยนไปข้อ 2)
**`//label[./descendant-or-self::*[${compare}='${label}']]/@for`**

สุดท้าย เพื่อป้องกันในกรณีที่มี label ชื่อเดียวกันมากกว่าหนึ่งอัน (เจอได้ในหน้า [Business Structure](https://pinkporn.github.io/em-robot/resources/BusinessStructure.html)) จึงใส่ `(...)[last()]` ครอบเอาไว้ เลือกอันสุดท้ายเท่านั้น (element ที่เหมือนกันแต่มาทีหลังมักจะเป็น element สุดท้าย) จะทำให้ได้ xpath ดังนี้
**`(//label[./descendant-or-self::*[${compare}='${label}']]/@for)[last()]`**

### 2. คืนค่า WebElement ออกมาเลย ไม่คืน id แล้ว
สังเกตจากการใช้งาน ปกติพอได้ id ก็จะเอาไปใช้หา element ต่ออยู่ดี ไม่มีความจำเป็นที่จะต้องคืน id
ตัวอย่างที่ทำให้อยากเปลี่ยน
ไฟล์ EmissionFactor.resource, keyword _Enter Energy Emission Factor Form_ แบบเดิม
```
Enter Energy Emission Factor Form
    ...
    ${group}    Get Id From Label In Modal Form    Emission Group
    ${element}    Get WebElement    id:${group}         # <- ได้ id ก็เอามาหยิบ element
    VAR    ${emission group}    ${{'Energy' if $element.is_enabled() else 'SKIP'}}
    ...
```
แบบใหม่
```
Enter Energy Emission Factor Form
    ...
    ${element}    Get Element From Label    Emission Group
    VAR    ${emission group}    ${{'Energy' if $element.is_enabled() else 'SKIP'}}
    ...
```
ที่ตอนนั้นสร้าง _Get Id From Label In Modal Form_ ก็เพราะไม่รู้ว่า xpath มันหยิบ attribute เอามาใช้หาต่อได้เลย

เมื่อรู้ว่าสามารถหา for ของ element หนึ่งเพื่อเลือกจาก id ของอีก element ได้ จึงแก้ไขใส่ `//*[@id= ... ]`ครอบเข้าไป
ทำให้จะได้ xpath ดังนี้
`//*[@id=`**`(//label[./descendant-or-self::*[${compare}='${label}']]/@for)[last()]`**`]`

## Error ที่อาจจะเกิดขึ้น
หากใช้ _Get Element From Label_ แล้วใส่ argument label ที่ไม่มีอยู่ในหน้าเว็บ จะทำให้เกิด error ที่มีข้อความประมาณนี้โผล่ขึ้นมา
```
Element with locator '//*[@id=(//label[./descendant-or-self::*[text()='label']]/@for)[last()]]' not found.
```
แสดงว่า robot หา label ที่ให้มาไม่เจอ ลอง copy xpath ไปทดลองหาดู

## แผนในอนาคตสำหรับ _Get Element From Label_
แก้จาก
```
Get Element From Label
    [Documentation]
    ...    คืน WebElement ที่ id ตรงกับ for attribute ของ label ที่มีข้อความ ``label``
    ...
    ...    ``compare`` เป็นวิธีในการหาข้อความ ``label``
    [Arguments]    ${label}    ${compare}=text()
    VAR    ${label_for}    (//label[./descendant-or-self::*[${compare}='${label}']]/@for)[last()]
    ${element}    Get WebElement    //*[@id=${label_for}]
    RETURN    ${element}
```
ให้กลายเป็น
```
Get Element From Label
    [Documentation]
    ...    คืน WebElement ที่ id ตรงกับ for attribute ของ label ที่มีข้อความ ``label``
    ...
    ...    ``compare`` เป็นวิธีในการหาข้อความ ``label``
    ...
    ...    ``required`` หากใส่เป็น ``True`` จะ error เมื่อหา element ไม่เจอ
    ...    หากใส่เป็น ``False`` จะคืนค่า ``None`` เมื่อหา element ไม่เจอ
    [Arguments]    ${label}    ${compare}=text()    ${required}=${True}
    VAR    ${label_for}    (//label[./descendant-or-self::*[${compare}='${label}']]/@for)[last()]
    ${element}    Find WebElement    //*[@id=${label_for}]    required=${required}
    RETURN    ${element}
```
ทำให้สามารถเลือกได้ว่าจะเกิด error หรือจะให้คืนค่า None เมื่อหา element ไม่เจอ แต่ตอนนี้ยังไม่มีความจำเป็นที่จะต้องเลือก จึงไม่ได้ทำ บวกกับการแก้ไข _Get Element From Label_ จะไม่ส่งผลกระทบกับโค้ดเก่า (backward compatible) จึงไม่จำเป็นต้องรีบแก้

## ปัจฉิมลิขิต (Postscript)
update FormUtility document เรียบร้อย ลองเปิดดู
https://pinkporn.github.io/em-robot/resources/FormUtility.html

เพิ่มการข้าม release notes ให้แล้ว