### PR TITLE
Status Toast Keyword

### DIFF
--- a/addEF/Fuel/TestInputEF_Fuel.robot
+++ b/addEF/Fuel/TestInputEF_Fuel.robot
@@ -124,143 +124,110 @@ Add EM2-06
 Add EM2-07
     [Tags]    case 2
     [Documentation]    
-    ${id}    Get Last Running No
     Add Emission Page 1 2    ${ORGANIZATION}    ${SITES}[0]    Fuel
     Enter Fuel Form    from date=Apr 2023    to date=Apr 2023    asset name=Bike OU-1    
     ...    fuel=${FUEL}    publisher=${PUBLISHER}    amount=100
-    Click Element    //button[.='Save as Draft']
-    Wait Until Page Contains    Emission created successfully
-    Wait Until New Running No Is Visible    ${id}
+    Save Emission As Draft
     Check Record Emission    scope 1=10.00 kg
     Click Delete Emission
 
 Add EM2-08
     [Tags]    case 2
     [Documentation]    
-    ${id}    Get Last Running No
     Add Emission Page 1 2    ${ORGANIZATION}    ${SITES}[0]    Fuel
     Enter Fuel Form    from date=Apr 2023    to date=May 2023    asset name=Bike OU-1    
     ...    fuel=${FUEL}    publisher=${PUBLISHER}    amount=100
-    Click Element    //button[.='Save as Draft']
-    Wait Until Page Contains    Emission created successfully
-    Wait Until New Running No Is Visible    ${id}
+    Save Emission As Draft
     Check Record Emission    scope 1=10.00 kg    scope 3=10.16 kg
     Click Delete Emission
 
 Add EM2-09
     [Tags]    case 2
     [Documentation]    
-    ${id}    Get Last Running No
     Add Emission Page 1 2    ${ORGANIZATION}    ${SITES}[0]    Fuel
     Enter Fuel Form    from date=Apr 2023    to date=Jun 2023    asset name=Bike OU-1    
     ...    fuel=${FUEL}    publisher=${PUBLISHER}    amount=100
-    Click Element    //button[.='Save as Draft']
-    Wait Until Page Contains    Emission created successfully
-    Wait Until New Running No Is Visible    ${id}
+    Save Emission As Draft
     Check Record Emission    scope 1=19.89 kg    scope 3=23.30 kg
     Click Delete Emission
 
 Add EM2-10
     [Tags]    case 2
     [Documentation]    
-    ${id}    Get Last Running No
     Add Emission Page 1 2    ${ORGANIZATION}    ${SITES}[0]    Fuel
     Enter Fuel Form    from date=Apr 2023    to date=Oct 2023    asset name=Bike OU-1    
     ...    fuel=${FUEL}    publisher=${PUBLISHER}    amount=100
-    Click Element    //button[.='Save as Draft']
-    Wait Until Page Contains    Emission created successfully
-    Wait Until New Running No Is Visible    ${id}
+    Save Emission As Draft
     Check Record Emission    scope 1=40.05 kg    scope 3=38.64 kg
     Click Delete Emission
 
 Add EM2-11
     [Tags]    case 2
     [Documentation]    
-    ${id}    Get Last Running No
     Add Emission Page 1 2    ${ORGANIZATION}    ${SITES}[0]    Fuel
     Enter Fuel Form    from date=Jun 2023    to date=Jul 2023    asset name=Bike OU-1    
     ...    fuel=${FUEL}    publisher=${PUBLISHER}    amount=100
-    Click Element    //button[.='Save as Draft']
-    Wait Until Page Contains    Emission created successfully
-    Wait Until New Running No Is Visible    ${id}
+    Save Emission As Draft
     Check Record Emission    scope 1=40.00 kg    scope 3=50.00 kg
     Click Delete Emission
 
 Add EM2-12
     [Tags]    case 2
     [Documentation]    Scope 1 เปลี่ยนค่า EF ส่วน Scope 3 และ Out of Scope ใช้ EF ค่าเดียว    
-    ${id}    Get Last Running No
     Add Emission Page 1 2    ${ORGANIZATION}    ${SITES}[0]    Fuel
     Enter Fuel Form    from date=Jun 2023    to date=Sep 2023    asset name=Bike OU-1    
     ...    fuel=${FUEL}    publisher=${PUBLISHER}    amount=100
-    Click Element    //button[.='Save as Draft']
-    Wait Until Page Contains    Emission created successfully
-    Wait Until New Running No Is Visible    ${id}
+    Save Emission As Draft
     Check Record Emission    scope 1=50.00 kg    scope 3=50.00 kg
     Click Delete Emission
 
 Add EM2-13
     [Tags]    case 2
     [Documentation]    เหมือน EM-12 แต่เดือน OCT Scope 1 ยังไม่มี EF ใหม่ ให้ใช้ค่าเดิมต่อจากเดือน SEP        
-    ${id}    Get Last Running No
     Add Emission Page 1 2    ${ORGANIZATION}    ${SITES}[0]    Fuel
     Enter Fuel Form    from date=Jun 2023    to date=Oct 2023    asset name=Bike OU-1    
     ...    fuel=${FUEL}    publisher=${PUBLISHER}    amount=100
-    Click Element    //button[.='Save as Draft']
-    Wait Until Page Contains    Emission created successfully
-    Wait Until New Running No Is Visible    ${id}
+    Save Emission As Draft
     Check Record Emission    scope 1=52.03 kg    scope 3=50.00 kg    outside of scope=18.04 kg
     Click Delete Emission
 
 Add EM2-14
     [Tags]    case 2
     [Documentation]    Scope 1,3 ใช้ค่าตามที่มี ส่วน Out of Scope ใช้ค่าเดิมจากเดือน MAY    
-    ${id}    Get Last Running No
     Add Emission Page 1 2    ${ORGANIZATION}    ${SITES}[0]    Fuel
     Enter Fuel Form    from date=Aug 2023    to date=Sep 2023    asset name=Bike OU-1    
     ...    fuel=${FUEL}    publisher=${PUBLISHER}    amount=100
-    Click Element    //button[.='Save as Draft']
-    Wait Until Page Contains    Emission created successfully
-    Wait Until New Running No Is Visible    ${id}
+    Save Emission As Draft
     Check Record Emission    scope 1=60.00 kg    scope 3=50.00 kg    outside of scope=30.00 kg
     Click Delete Emission
 
 Add EM2-15
     [Tags]    case 2
     [Documentation]     ช่วงที่เกินจาก Effective Date ให้ใช้ค่าเดิมต่อไป
-    ${id}    Get Last Running No
     Add Emission Page 1 2    ${ORGANIZATION}    ${SITES}[0]    Fuel
     Enter Fuel Form    from date=Aug 2023    to date=Dec 2023    asset name=Bike OU-1    
     ...    fuel=${FUEL}    publisher=${PUBLISHER}    amount=100
-    Click Element    //button[.='Save as Draft']
-    Wait Until Page Contains    Emission created successfully
-    Wait Until New Running No Is Visible    ${id}
+    Save Emission As Draft
     Check Record Emission    scope 1=60.00 kg    scope 3=50.00 kg    outside of scope=30.00 kg
     Click Delete Emission
 
 Add EM2-16
     [Tags]    case 2
     [Documentation]    ช่วงที่เกินจาก Effective Date ให้ใช้ค่าเดิมต่อไป    
-    ${id}    Get Last Running No
     Add Emission Page 1 2    ${ORGANIZATION}    ${SITES}[0]    Fuel
     Enter Fuel Form    from date=Oct 2023    to date=Dec 2023    asset name=Bike OU-1    
     ...    fuel=${FUEL}    publisher=${PUBLISHER}    amount=100
-    Click Element    //button[.='Save as Draft']
-    Wait Until Page Contains    Emission created successfully
-    Wait Until New Running No Is Visible    ${id}
+    Save Emission As Draft
     Check Record Emission    scope 1=60.00 kg    scope 3=50.00 kg    outside of scope=30.00 kg
     Click Delete Emission
 
 Add EM2-17
     [Tags]    case 2
     [Documentation]    ช่วงที่เกินจาก Effective Date ให้ใช้ค่าเดิมต่อไป    
-    ${id}    Get Last Running No
     Add Emission Page 1 2    ${ORGANIZATION}    ${SITES}[0]    Fuel
     Enter Fuel Form    from date=Nov 2023    to date=Dec 2023    asset name=Bike OU-1    
     ...    fuel=${FUEL}    publisher=${PUBLISHER}    amount=100
-    Click Element    //button[.='Save as Draft']
-    Wait Until Page Contains    Emission created successfully
-    Wait Until New Running No Is Visible    ${id}
+    Save Emission As Draft
     Check Record Emission    scope 1=60.00 kg    scope 3=50.00 kg    outside of scope=30.00 kg
     Click Delete Emission
 
@@ -321,143 +288,110 @@ Add EM2-17
 Add EM3-07
     [Tags]    case 3
     [Documentation]    
-    ${id}    Get Last Running No
     Add Emission Page 1 2    ${ORGANIZATION}    ${SITES}[0]    Fuel
     Enter Fuel Form    from date=Apr 2023    to date=Apr 2023    asset name=Bike OU-1    
     ...    fuel=${FUEL}    publisher=${PUBLISHER}    amount=100
-    Click Element    //button[.='Save as Draft']
-    Wait Until Page Contains    Emission created successfully
-    Wait Until New Running No Is Visible    ${id}
+    Save Emission As Draft
     Check Record Emission    scope 1=10.00 kg    outside of scope=30.00 kg
     Click Delete Emission
 
 Add EM3-08
     [Tags]    case 3
     [Documentation]    
-    ${id}    Get Last Running No
     Add Emission Page 1 2    ${ORGANIZATION}    ${SITES}[0]    Fuel
     Enter Fuel Form    from date=Apr 2023    to date=May 2023    asset name=Bike OU-1    
     ...    fuel=${FUEL}    publisher=${PUBLISHER}    amount=100
-    Click Element    //button[.='Save as Draft']
-    Wait Until Page Contains    Emission created successfully
-    Wait Until New Running No Is Visible    ${id}
+    Save Emission As Draft
     Check Record Emission    scope 1=10.00 kg    outside of scope=30.00 kg
     Click Delete Emission
 
 Add EM3-09
     [Tags]    case 3
     [Documentation]    Out of Scope เดือน JUN ใช้ของใหม่ตามที่มี
-    ${id}    Get Last Running No
     Add Emission Page 1 2    ${ORGANIZATION}    ${SITES}[0]    Fuel
     Enter Fuel Form    from date=Apr 2023    to date=Jun 2023    asset name=Bike OU-1    
     ...    fuel=${FUEL}    publisher=${PUBLISHER}    amount=100
-    Click Element    //button[.='Save as Draft']
-    Wait Until Page Contains    Emission created successfully
-    Wait Until New Running No Is Visible    ${id}
+    Save Emission As Draft
     Check Record Emission    scope 1=19.89 kg        scope 3=16.48 kg    outside of scope=43.19 kg
     Click Delete Emission
 
 Add EM3-10
     [Tags]    case 3
     [Documentation]    Out of Scope เดือน JUN - OCT ใช้ของใหม่ตามที่มี
-    ${id}    Get Last Running No
     Add Emission Page 1 2    ${ORGANIZATION}    ${SITES}[0]    Fuel
     Enter Fuel Form    from date=Apr 2023    to date=Oct 2023    asset name=Bike OU-1    
     ...    fuel=${FUEL}    publisher=${PUBLISHER}    amount=100
-    Click Element    //button[.='Save as Draft']
-    Wait Until Page Contains    Emission created successfully
-    Wait Until New Running No Is Visible    ${id}
+    Save Emission As Draft
     Check Record Emission    scope 1=40.05 kg        scope 3=35.75 kg    outside of scope=58.60 kg
     Click Delete Emission
 
 Add EM3-11
     [Tags]    case 3
     [Documentation]
-    ${id}    Get Last Running No
     Add Emission Page 1 2    ${ORGANIZATION}    ${SITES}[0]    Fuel
     Enter Fuel Form    from date=Jun 2023    to date=Jul 2023    asset name=Bike OU-1    
     ...    fuel=${FUEL}    publisher=${PUBLISHER}    amount=100
-    Click Element    //button[.='Save as Draft']
-    Wait Until Page Contains    Emission created successfully
-    Wait Until New Running No Is Visible    ${id}
+    Save Emission As Draft
     Check Record Emission    scope 1=40.00 kg        scope 3=50.00 kg    outside of scope=70.00 kg
     Click Delete Emission
 
 Add EM3-12
     [Tags]    case 3
     [Documentation]    Scope 1 เปลี่ยนค่า EF ส่วน Scope 3 และ Out of Scope ใช้ EF ค่าเดียว
-    ${id}    Get Last Running No
     Add Emission Page 1 2    ${ORGANIZATION}    ${SITES}[0]    Fuel
     Enter Fuel Form    from date=Jun 2023    to date=Sep 2023    asset name=Bike OU-1    
     ...    fuel=${FUEL}    publisher=${PUBLISHER}    amount=100
-    Click Element    //button[.='Save as Draft']
-    Wait Until Page Contains    Emission created successfully
-    Wait Until New Running No Is Visible    ${id}
+    Save Emission As Draft
     Check Record Emission    scope 1=50.00 kg        scope 3=50.00 kg    outside of scope=70.00 kg
     Click Delete Emission
 
 Add EM3-13
     [Tags]    case 3
     [Documentation]    เหมือน EM-12 แต่เดือน OCT Scope 1 ยังไม่มี EF ใหม่ ให้ใช้ค่าเดิมต่อจากเดือน SEP
-    ${id}    Get Last Running No
     Add Emission Page 1 2    ${ORGANIZATION}    ${SITES}[0]    Fuel
     Enter Fuel Form    from date=Jun 2023    to date=Oct 2023    asset name=Bike OU-1    
     ...    fuel=${FUEL}    publisher=${PUBLISHER}    amount=100
-    Click Element    //button[.='Save as Draft']
-    Wait Until Page Contains    Emission created successfully
-    Wait Until New Running No Is Visible    ${id}
+    Save Emission As Draft
     Check Record Emission    scope 1=52.03 kg        scope 3=50.00 kg    outside of scope=70.00 kg
     Click Delete Emission
 
 Add EM3-14
     [Tags]    case 3
     [Documentation]    Scope 1,3 ใช้ค่าตามที่มี ส่วน Out of Scope ใช้ค่าเดิมจากเดือน MAY
-    ${id}    Get Last Running No
     Add Emission Page 1 2    ${ORGANIZATION}    ${SITES}[0]    Fuel
     Enter Fuel Form    from date=Aug 2023    to date=Sep 2023    asset name=Bike OU-1    
     ...    fuel=${FUEL}    publisher=${PUBLISHER}    amount=100
-    Click Element    //button[.='Save as Draft']
-    Wait Until Page Contains    Emission created successfully
-    Wait Until New Running No Is Visible    ${id}
+    Save Emission As Draft
     Check Record Emission    scope 1=60.00 kg        scope 3=50.00 kg    outside of scope=70.00 kg
     Click Delete Emission
 
 Add EM3-15
     [Tags]    case 3
     [Documentation]    ช่วงที่เกินจาก Effective Date ให้ใช้ค่าเดิมต่อไป
-    ${id}    Get Last Running No
     Add Emission Page 1 2    ${ORGANIZATION}    ${SITES}[0]    Fuel
     Enter Fuel Form    from date=Aug 2023    to date=Dec 2023    asset name=Bike OU-1    
     ...    fuel=${FUEL}    publisher=${PUBLISHER}    amount=100
-    Click Element    //button[.='Save as Draft']
-    Wait Until Page Contains    Emission created successfully
-    Wait Until New Running No Is Visible    ${id}
+    Save Emission As Draft
     Check Record Emission    scope 1=60.00 kg        scope 3=50.00 kg    outside of scope=70.00 kg
     Click Delete Emission
 
 Add EM3-16
     [Tags]    case 3
     [Documentation]    ช่วงที่เกินจาก Effective Date ให้ใช้ค่าเดิมต่อไป
-    ${id}    Get Last Running No
     Add Emission Page 1 2    ${ORGANIZATION}    ${SITES}[0]    Fuel
     Enter Fuel Form    from date=Oct 2023    to date=Dec 2023    asset name=Bike OU-1    
     ...    fuel=${FUEL}    publisher=${PUBLISHER}    amount=100
-    Click Element    //button[.='Save as Draft']
-    Wait Until Page Contains    Emission created successfully
-    Wait Until New Running No Is Visible    ${id}
+    Save Emission As Draft
     Check Record Emission    scope 1=60.00 kg        scope 3=50.00 kg    outside of scope=70.00 kg
     Click Delete Emission
 
 Add EM3-17
     [Tags]    case 3
     [Documentation]    ช่วงที่เกินจาก Effective Date ให้ใช้ค่าเดิมต่อไป
-    ${id}    Get Last Running No
     Add Emission Page 1 2    ${ORGANIZATION}    ${SITES}[0]    Fuel
     Enter Fuel Form    from date=Nov 2023    to date=Dec 2023    asset name=Bike OU-1    
     ...    fuel=${FUEL}    publisher=${PUBLISHER}    amount=100
-    Click Element    //button[.='Save as Draft']
-    Wait Until Page Contains    Emission created successfully
-    Wait Until New Running No Is Visible    ${id}
+    Save Emission As Draft
     Check Record Emission    scope 1=60.00 kg        scope 3=50.00 kg    outside of scope=70.00 kg
     Click Delete Emission
 

--- a/inputEmission/TestInputBusiness.robot
+++ b/inputEmission/TestInputBusiness.robot
@@ -15,13 +15,10 @@ Add & Check Emission
     ...    ${no emission}=${False}
     ...    ${delete}=${True}
     
-    ${id}    Get Last Running No
     Add Emission Page 1 2    ${SUB ORG}    ${site name}    Business Travel
     Enter Employee Commuting or Business Travel Form   mode=${mode}    haul=${haul}    
     ...    flight class=${flight class}    distance=${distance}    unit=${unit}    amount=${amount}    
-    Click Element    //button[.//span[text()='Save as Draft']]
-    Wait Until Page Contains    Emission created successfully
-    Wait Until New Running No Is Visible    ${id}
+    Save Emission As Draft
     Check Record Emission
     ...    scope 1=${scope 1}
     ...    scope 3=${scope 3}

--- a/inputEmission/TestInputDisposal.robot
+++ b/inputEmission/TestInputDisposal.robot
@@ -15,13 +15,10 @@ Add & Check Emission
     ...    ${no emission}=${False}
     ...    ${delete}=${True}
     
-    ${id}    Get Last Running No
     Add Emission Page 1 2    ${SUB ORG}    ${site name}    Outsourcing Waste Disposal
     Enter Outsourcing Waste Disposal Form         category=${category}    waste type=${waste type}    
     ...    treatment=${treatment}    amount=${amount}
-    Click Element    //button[.//span[text()='Save as Draft']]
-    Wait Until Page Contains    Emission created successfully
-    Wait Until New Running No Is Visible    ${id}
+    Save Emission As Draft
     Check Record Emission
     ...    scope 1=${scope 1}
     ...    scope 3=${scope 3}

--- a/inputEmission/TestInputEmp.robot
+++ b/inputEmission/TestInputEmp.robot
@@ -15,13 +15,10 @@ Add & Check Emission
     ...    ${no emission}=${False}    
     ...    ${delete}=${True}
     
-    ${id}    Get Last Running No
     Add Emission Page 1 2    ${SUB ORG}    ${site name}    Employee Commuting
     Enter Employee Commuting or Business Travel Form   mode=${mode}    vehicle type=${vehicle type}    
     ...    fuel type=${fuel type}    distance=${distance}    unit=${unit}    amount=${amount}    
-    Click Element    //button[.//span[text()='Save as Draft']]
-    Wait Until Page Contains    Emission created successfully
-    Wait Until New Running No Is Visible    ${id}
+    Save Emission As Draft
     Check Record Emission
     ...    scope 1=${scope 1}
     ...    scope 3=${scope 3}

--- a/inputEmission/TestInputEnergy.robot
+++ b/inputEmission/TestInputEnergy.robot
@@ -17,13 +17,10 @@ Add & Check Emission
     ...    ${no emission}=${False}    
     ...    ${delete}=${True}
     
-    ${id}    Get Last Running No
     Add Emission Page 1 2    ${SUB ORG}    ${site name}   Energy
     Enter Energy Form    asset type=${asset type}   asset name=${asset name}
     ...    source=${source}    unit=${unit}    amount=${amount}    resell=${resell}
-    Click Element    //button[.//span[text()='Save as Draft']]
-    Wait Until Page Contains    Emission created successfully
-    Wait Until New Running No Is Visible    ${id}
+    Save Emission As Draft
     Check Record Emission
     ...    scope 2=${scope 2}
     ...    scope 3=${scope 3}

--- a/inputEmission/TestInputFertilizer.robot
+++ b/inputEmission/TestInputFertilizer.robot
@@ -17,13 +17,10 @@ Add & Check Emission
     ...    ${no emission}=${False}    
     ...    ${delete}=${True}
     
-    ${id}    Get Last Running No
     Add Emission Page 1 2    ${SUB ORG}    ${site name}   Fertilizer
     Enter Fertilizer Form    fertilizer type=${fertilizer type}    n=${n}    p=${p}    k=${k}    
     ...    unit=${unit}    amount=${amount}
-    Click Element    //button[.//span[text()='Save as Draft']]
-    Wait Until Page Contains    Emission created successfully
-    Wait Until New Running No Is Visible    ${id}
+    Save Emission As Draft
     Check Record Emission
     ...    scope 1=${scope 1}
     ...    scope 3=${scope 3}

--- a/inputEmission/TestInputFire.robot
+++ b/inputEmission/TestInputFire.robot
@@ -16,12 +16,9 @@ Add & Check Emission
     ...    ${no emission}=${False}
     ...    ${delete}=${True}
     
-    ${id}    Get Last Running No
     Add Emission Page 1 2    ${SUB ORG}    ${site name}    Fire Extinguishing
     Enter Fire Extinguishing Form     asset name=${asset name}    agent=${agent}    amount=${amount}
-    Click Element    //button[.//span[text()='Save as Draft']]
-    Wait Until Page Contains    Emission created successfully
-    Wait Until New Running No Is Visible    ${id}
+    Save Emission As Draft
     Check Record Emission
     ...    scope 1=${scope 1}
     ...    scope 3=${scope 3}

--- a/inputEmission/TestInputFuel.robot
+++ b/inputEmission/TestInputFuel.robot
@@ -14,13 +14,10 @@ Add & Check Fuel Emission
     ...    ${scope 1}=${None}    ${scope 3}=${None}    ${outside of scope}=${None}
     ...    ${delete}=${True}
     
-    ${id}    Get Last Running No
     Add Emission Page 1 2    ${SUB ORG}    ${site name}    Fuel
     Enter Fuel Form    asset name=${asset name}    fuel=${fuel name}
     ...    unit=${unit}    amount=${amount}    asset type=${asset type}
-    Click Element    //button[.//span[text()='Save as Draft']]
-    Wait Until Page Contains    Emission created successfully
-    Wait Until New Running No Is Visible    ${id}
+    Save Emission As Draft
     Check Record Emission
     ...    scope 1=${scope 1}
     ...    scope 3=${scope 3}

--- a/inputEmission/TestInputFugitive.robot
+++ b/inputEmission/TestInputFugitive.robot
@@ -14,12 +14,9 @@ Add & Check Emission
     ...    ${no emission}=${False}
     ...    ${delete}=${True}
     
-    ${id}    Get Last Running No
     Add Emission Page 1 2    ${SUB ORG}    ${site name}    Other Fugitive Emission
-    Enter Other Fugitive Emission Form         source=${source}    amount=${amount}
-    Click Element    //button[.//span[text()='Save as Draft']]
-    Wait Until Page Contains    Emission created successfully
-    Wait Until New Running No Is Visible    ${id}
+    Enter Other Fugitive Emission Form    source=${source}    amount=${amount}
+    Save Emission As Draft
     Check Record Emission
     ...    scope 1=${scope 1}
     ...    scope 3=${scope 3}

--- a/inputEmission/TestInputPurchase.robot
+++ b/inputEmission/TestInputPurchase.robot
@@ -15,13 +15,10 @@ Add & Check Emission
     ...    ${no emission}=${False}
     ...    ${delete}=${True}
     
-    ${id}    Get Last Running No
     Add Emission Page 1 2    ${SUB ORG}    ${site name}    Purchases
-    Enter Purchases Form         capital goods=${capital goods}    name=${name}    
+    Enter Purchases Form    capital goods=${capital goods}    name=${name}    
     ...    goods services=${goods services}    amount=${amount}
-    Click Element    //button[.//span[text()='Save as Draft']]
-    Wait Until Page Contains    Emission created successfully
-    Wait Until New Running No Is Visible    ${id}
+    Save Emission As Draft
     Check Record Emission
     ...    scope 1=${scope 1}
     ...    scope 3=${scope 3}

--- a/inputEmission/TestInputRefrigerants.robot
+++ b/inputEmission/TestInputRefrigerants.robot
@@ -14,12 +14,9 @@ Add & Check Emission
     ...    ${no emission}=${False}
     ...    ${delete}=${True}
     
-    ${id}    Get Last Running No
     Add Emission Page 1 2    ${SUB ORG}    ${site name}    Refrigerants
     Enter Refrigerants Form     asset name=${asset name}    refrigerant=${refrigerant}    amount=${amount}
-    Click Element    //button[.//span[text()='Save as Draft']]
-    Wait Until Page Contains    Emission created successfully
-    Wait Until New Running No Is Visible    ${id}
+    Save Emission As Draft
     Check Record Emission
     ...    scope 1=${scope 1}
     ...    scope 3=${scope 3}

--- a/inputEmission/TestInputSeptic.robot
+++ b/inputEmission/TestInputSeptic.robot
@@ -14,12 +14,9 @@ Add & Check Emission
     ...    ${no emission}=${False}    ${delete}=${True}
     ...    &{days}
     
-    ${id}    Get Last Running No
     Add Emission Page 1 2    ${SUB ORG}    ${site name}    Septic Tank
     Enter Septic Tank Form   ${from date}    ${to date}     amount=${amount}    &{days}
-    Click Element    //button[.//span[text()='Save as Draft']]
-    Wait Until Page Contains    Emission created successfully
-    Wait Until New Running No Is Visible    ${id}
+    Save Emission As Draft
     Check Record Emission
     ...    scope 1=${scope 1}
     ...    scope 3=${scope 3}

--- a/inputEmission/TestInputTransport.robot
+++ b/inputEmission/TestInputTransport.robot
@@ -17,13 +17,10 @@ Add & Check Emission
     ...    ${no emission}=${False}    
     ...    ${delete}=${True}
     
-    ${id}    Get Last Running No
     Add Emission Page 1 2    ${SUB ORG}    ${site name}    Outsourcing Transport
     Enter Outsourcing Transport Form   goods type=${goods type}    goods name=${goods name}    source=${source}
     ...    distance=${distance}    distance unit=${distance unit}     loading=${loading}    loading unit=${loading unit}   
-    Click Element    //button[.//span[text()='Save as Draft']]
-    Wait Until Page Contains    Emission created successfully
-    Wait Until New Running No Is Visible    ${id}
+    Save Emission As Draft
     Check Record Emission
     ...    scope 1=${scope 1}
     ...    scope 3=${scope 3}

--- a/inputEmission/TestInputWater.robot
+++ b/inputEmission/TestInputWater.robot
@@ -14,12 +14,9 @@ Add & Check Emission
     ...    ${no emission}=${False}
     ...    ${delete}=${True}
     
-    ${id}    Get Last Running No
     Add Emission Page 1 2    ${SUB ORG}    ${site name}    Water
     Enter Water Form         water type=${water type}    amount=${amount}
-    Click Element    //button[.//span[text()='Save as Draft']]
-    Wait Until Page Contains    Emission created successfully
-    Wait Until New Running No Is Visible    ${id}
+    Save Emission As Draft
     Check Record Emission
     ...    scope 1=${scope 1}
     ...    scope 3=${scope 3}

--- a/resources/EmissionFactor.resource
+++ b/resources/EmissionFactor.resource
@@ -224,17 +224,28 @@ Enter Water Emission Factor Form
 
 Confirm Add EF
     Click Element    //button[.="Add"]
+    Wait Until Toast Finish Loading
+    Toast Status Should Be    Successful
+    Toast Message Should Be    Emission Factor created successfully
     Wait Until Element Is Not Visible    //section
-    Wait Until Page Contains    Emission Factor created successfully
 
 Confirm Add EF Expect Invalid Date
     Click Element    //button[.="Add"]
-    Wait Until Element Is Visible    //span[contains(text(), "Invalid Start Date or End Date for this emission factor.")]
-    # Wait Until Element Is Not Visible    //span[contains(text(), "Invalid Start Date or End Date for this emission factor.")]
+    Wait Until Toast Finish Loading
+    Toast Status Should Be    Failed
+    VAR    ${invalid date message}    SEPARATOR=
+    ...    Invalid Start Date or End Date for this emission factor.\n
+    ...    \n
+    ...    Please make sure that the start date is adjacent to
+    ...     the end date of the previous emission factor with the same attributes.
+    Toast Message Should Be    ${invalid date message}
+    ...    error=Expected toast message:\n"<TEXT>"\nFound:\n"<ACTUAL_TEXT>"
     Click Close Modal
 
 Confirm Add EF Expect Overlap Date
     Click Element    //button[.="Add"]
+    Wait Until Toast Finish Loading
+    Toast Status Should Be    Failed
     Wait Until Element Is Visible    //section//button[.="Understand"]
     Click Element    //section//button[.="Understand"]
     Wait Until Element Is Not Visible    //section//button[.="Understand"]

--- a/resources/FormUtility.resource
+++ b/resources/FormUtility.resource
@@ -289,19 +289,13 @@ Click ${menu} Menu Button
     Click Button                     (//div[@role="menu"])[last()]//button[.='${menu}']
 
 Upload Evidences
-    [Documentation]    อัปโหลดหลักฐานใน drop zone สามารถใส่ค่าสุดท้ายเป็น ``timeout`` ได้
+    [Documentation]    อัปโหลดหลักฐานใน drop zone ใส่ ``timeout=เวลา`` ไว้หลังสุดเพื่อกำหนด ``timeout``
     ...    ---
     ...    Examples:
     ...    | Upload Evidences | \${EXECDIR}/evidences/test.pdf |              | # อัปโหลดไฟล์เดียว |
     ...    | Upload Evidences | \${CURDIR}/pic-1.png   | \${CURDIR}/pic-2.png | # อัปโหลดสองไฟล์  |
-    ...    | Upload Evidences | \${CURDIR}/bigFile.pdf | 30                   | # อัปโหลดไฟล์เดียว รอนานสุด 30 วินาที |
-    [Arguments]    @{files}
-    TRY
-        ${timeout}    Evaluate    SeleniumLibrary.utils._convert_timeout($files[-1])    modules=SeleniumLibrary.utils
-        Evaluate    $files.pop()
-    EXCEPT
-        VAR    ${timeout}    ${None}
-    END
+    ...    | Upload Evidences | \${CURDIR}/bigFile.pdf | timeout=30           | # อัปโหลดไฟล์เดียว รอนานสุด 30 วินาที |
+    [Arguments]    @{files}    ${timeout}=${None}
     IF  len($files) == 0    RETURN
     ${paths}    Catenate    SEPARATOR=${\n}    @{files}
     Scroll Element Into View    //div[./input[@accept and @type='file']]

--- a/resources/FormUtility.resource
+++ b/resources/FormUtility.resource
@@ -328,6 +328,8 @@ Wait Until New Running No Is Visible
     IF  $timeout is None
         ${selenium}    Get Library Instance    SeleniumLibrary
         VAR    ${timeout}    ${selenium.timeout}
+    ELSE
+        ${timeout}    Evaluate    robot.utils.timestr_to_secs($timeout)    modules=robot.utils
     END
     ${max_time}    Evaluate    time.time() + $timeout    modules=time
     WHILE  time.time() < $max_time

--- a/resources/FormUtility.resource
+++ b/resources/FormUtility.resource
@@ -374,6 +374,8 @@ Get Toast Status
     ...
     ...    ค่าที่สามารถคืนได้คือ "SUCCESS", "FAIL", "LOADING" และ "UNKNOWN"
     ...    และคืนค่า ``None`` ถ้าไม่เจอ toast status
+    ...
+    ...    อ่านเพิ่มเติมที่ [https://github.com/Pinkporn/em-robot/pull/9#get-toast-status| pull request 9]
     [Arguments]    ${toast no}=1    @{}    ${required}=${False}
     VAR    ${symbol_xpath}    ((//div[@role='status'])[${toast no}]/..//div[not(node())])[last()]
     ${status}    Find WebElement    ${symbol_xpath}    required=${required}
@@ -398,6 +400,8 @@ Get Toast Text
     ...    บางครั้ง toast มีมากกว่า 1 ข้อความเช่น error toast ที่มี code อยู่ข้างล่าง
     ...    โดยค่าเริ่มต้น ``result`` คือ 1 แปลว่าคืนข้อความปกติของ toast
     ...    สามารถใส่ ``result`` เป็น last() ได้ถ้าหากต้องการตรวจสอบข้อความจาก error code แทน
+    ...
+    ...    อ่านเพิ่มเติมที่ [https://github.com/Pinkporn/em-robot/pull/9#get-toast-text| pull request 9]
     [Arguments]    ${toast no}=1    ${result}=1
     ${status_text}    Get Text    ((//div[@role='status'])[${toast no}]/descendant-or-self::*[text()])[${result}]
     RETURN    ${status_text}
@@ -408,6 +412,8 @@ Wait Until Toast Finish Loading
     ...    ``timeout``: Fail ถ้ารอนานเกินเวลาที่กำหนด
     ...
     ...    ``toast no`` คือลำดับความใหม่ของ toast
+    ...
+    ...    อ่านเพิ่มเติมที่ [https://github.com/Pinkporn/em-robot/pull/9#wait-until-toast-finish-loading| pull request 9]
     [Arguments]    ${timeout}=${None}    ${toast no}=1
     IF  $timeout is None
         ${selenium}    Get Library Instance    SeleniumLibrary
@@ -435,6 +441,8 @@ Toast Status Should Be
     ...    และแทนที่ <ACTUAL_TEXT> ด้วยข้อความของ toast
     ...
     ...    ``toast no`` คือลำดับความใหม่ของ toast
+    ...
+    ...    อ่านเพิ่มเติมที่ [https://github.com/Pinkporn/em-robot/pull/9#toast-status-should-be| pull request 9]
     [Arguments]
     ...    ${status}
     ...    ${error}=Toast status: expected "<STATUS>", found "<ACTUAL_STATUS>" with message "<ACTUAL_TEXT>"
@@ -465,6 +473,8 @@ Toast Message Should Be
     ...
     ...    สามารถใส่ ``error`` ถ้าต้องการกำหนดข้อความ error เองเมื่อข้อความไม่ถูกต้อง
     ...    keyword จะแทนที่ <TEXT> ด้วย ``text`` และแทนที่ <ACTUAL_TEXT> ด้วยข้อความของ toast
+    ...
+    ...    อ่านเพิ่มเติมที่ [https://github.com/Pinkporn/em-robot/pull/9#toast-message-should-be| pull request 9]
     [Arguments]
     ...    ${text}
     ...    ${condition}=$text == $actual_text

--- a/resources/FormUtility.resource
+++ b/resources/FormUtility.resource
@@ -368,6 +368,7 @@ Field Message Should Be
 Get Toast Status
     [Documentation]    คืนค่าสถานะของ toast อันที่ ``toast no``
     ...
+    ...    ``toast no`` คือลำดับความใหม่ของ toast
     ...    ``toast no``=1 คือ toast ใหม่ล่าสุด
     ...    ``toast no``=2 คือ toast ใหม่ลองลงมา
     ...
@@ -403,6 +404,10 @@ Get Toast Text
 
 Wait Until Toast Finish Loading
     [Documentation]    รอจนกว่า toast จะ load เสร็จ
+    ...
+    ...    ``timeout``: Fail ถ้ารอนานเกินเวลาที่กำหนด
+    ...
+    ...    ``toast no`` คือลำดับความใหม่ของ toast
     [Arguments]    ${timeout}=${None}    ${toast no}=1
     IF  $timeout is None
         ${selenium}    Get Library Instance    SeleniumLibrary
@@ -428,6 +433,8 @@ Toast Status Should Be
     ...    สำหรับ ``error`` keyword จะแทนที่ <STATUS> ด้วย ``status``
     ...    แทนที่ <ACTUAL_STATUS> ด้วยสถานะที่พบของ toast
     ...    และแทนที่ <ACTUAL_TEXT> ด้วยข้อความของ toast
+    ...
+    ...    ``toast no`` คือลำดับความใหม่ของ toast
     [Arguments]
     ...    ${status}
     ...    ${error}=Toast status: expected "<STATUS>", found "<ACTUAL_STATUS>" with message "<ACTUAL_TEXT>"
@@ -449,6 +456,8 @@ Toast Message Should Be
     ...    ``condition`` ใช้สำหรับการตรวจสอบข้อความ fail เมื่อ ``condition`` เป็นเท็จ
     ...    ใช้ ``$text == $actual_text`` เมื่อต้องการดูว่าข้อความเหมือนกัน
     ...    ใช้ ``$text in $actual_text`` เมื่อต้องการดูว่า ``text`` อยู่ในข้อความของ toast
+    ...
+    ...    ``toast no`` คือลำดับความใหม่ของ toast
     ...
     ...    บางครั้ง error toast มีมากกว่า 1 ข้อความเช่นมี code อยู่ข้างล่าง
     ...    โดยค่าเริ่มต้น ``result`` คือ 1 แปลว่าตรวจข้อความปกติของ toast

--- a/resources/FormUtility.resource
+++ b/resources/FormUtility.resource
@@ -364,3 +364,105 @@ Field Message Should Be
     Should Be Equal    ${msg}    ${expected}
     ...    msg=Expected message to be "${expected}". Found "${msg}" instead.
     ...    values=${False}
+
+Get Toast Status
+    [Documentation]    คืนค่าสถานะของ toast อันที่ ``toast no``
+    ...
+    ...    ``toast no``=1 คือ toast ใหม่ล่าสุด
+    ...    ``toast no``=2 คือ toast ที่มาก่อนใหม่ล่าสุด
+    ...
+    ...    ค่าที่สามารถคืนได้คือ "SUCCESS", "FAIL", "LOADING" และ "UNKNOWN"
+    ...    และคืนค่า ``None`` ถ้าไม่เจอ toast status
+    [Arguments]    ${toast no}=1    @{}    ${required}=${False}
+    VAR    ${symbol_xpath}    ((//div[@role='status'])[${toast no}]/..//div[not(node())])[last()]
+    ${status}    Find WebElement    ${symbol_xpath}    required=${required}
+    IF  $status is None    RETURN
+    ${rgba}    Evaluate    ${status.value_of_css_property("background-color")}[4:]
+    IF  $rgba[1] > $rgba[0] and $rgba[1] > $rgba[2]
+        RETURN    SUCCESS
+    ELSE IF  $rgba[0] > $rgba[1] and $rgba[0] > $rgba[2]
+        RETURN    FAIL
+    ELSE IF  $rgba[3] == 0
+        RETURN    LOADING
+    ELSE
+        RETURN    UNKNOWN
+    END
+
+Get Toast Text
+    [Documentation]    คืนค่าข้อความของ toast อันที่ ``toast no``
+    ...
+    ...    ``toast no``=1 คือ toast ใหม่ล่าสุด
+    ...    ``toast no``=2 คือ toast ที่มาก่อนใหม่ล่าสุด
+    ...
+    ...    บางครั้ง toast มีมากกว่า 1 ข้อความเช่น error toast ที่มี code อยู่ข้างล่าง
+    ...    โดยค่าเริ่มต้น ``result`` คือ 1 แปลว่าคืนข้อความปกติของ toast
+    ...    สามารถใส่ ``result`` เป็น last() ได้ถ้าหากต้องการตรวจสอบข้อความจาก error code แทน
+    [Arguments]    ${toast no}=1    ${result}=1
+    ${status_text}    Get Text    ((//div[@role='status'])[${toast no}]/descendant-or-self::*[text()])[${result}]
+    RETURN    ${status_text}
+
+Wait Until Toast Finish Loading
+    [Documentation]    รอจนกว่า toast จะ load เสร็จ
+    [Arguments]    ${timeout}=${None}    ${toast no}=1
+    IF  $timeout is None
+        ${selenium}    Get Library Instance    SeleniumLibrary
+        VAR    ${timeout}    ${selenium.timeout}
+    ELSE
+        ${timeout}    Evaluate    robot.utils.timestr_to_secs($timeout)    modules=robot.utils
+    END
+    ${max_time}    Evaluate    time.time() + $timeout    modules=time
+    Wait Until Element Is Visible    (//div[@role='status'])[${toast no}]    ${timeout}
+    WHILE  time.time() < $max_time
+        ${status}    Get Toast Status    ${toast no}
+        IF  $status != 'LOADING'    RETURN
+        Sleep    0.2
+    END
+    Fail    Toast is still loading after ${timeout} seconds.
+
+Toast Status Should Be
+    [Documentation]    ตรวจสอบว่า toast มีสถานะเป็น ``status``
+    ...
+    ...    ``status`` ที่เป็นไปได้คือ Successful, Failed และ Loading
+    ...
+    ...    สามารถใส่ ``error`` ถ้าต้องการกำหนดข้อความ error เองเมื่อสถานะไม่ตรง
+    ...    สำหรับ ``error`` keyword จะแทนที่ <STATUS> ด้วย ``status``
+    ...    แทนที่ <ACTUAL_STATUS> ด้วยสถานะที่พบของ toast
+    ...    และแทนที่ <ACTUAL_TEXT> ด้วยข้อความของ toast
+    [Arguments]
+    ...    ${status}
+    ...    ${error}=Toast status: expected "<STATUS>", found "<ACTUAL_STATUS>" with message "<ACTUAL_TEXT>"
+    ...    ${toast no}=1
+
+    ${actual_status}    Get Toast Status    ${toast no}
+    VAR    ${status}    ${{ {'Successful':'SUCCESS', 'Failed':'FAIL', 'Loading':'LOADING'}.get($status, $status) }}
+    IF  $actual_status != $status
+        ${actual_text}    Get Toast Text    ${toast no}
+        ${error}    Replace String    ${error}    <STATUS>           ${status}
+        ${error}    Replace String    ${error}    <ACTUAL_STATUS>    ${actual_status}
+        ${error}    Replace String    ${error}    <ACTUAL_TEXT>      ${actual_text}
+        Fail    ${error}
+    END
+
+Toast Message Should Be
+    [Documentation]    เปรียบเทียบ ``text`` กับข้อความของ toast
+    ...
+    ...    ``condition`` ใช้สำหรับการตรวจสอบข้อความ fail เมื่อ ``condition`` เป็นเท็จ
+    ...    ใช้ ``$text == $actual_text`` เมื่อต้องการดูว่าข้อความเหมือนกัน
+    ...    ใช้ ``$text in $actual_text`` เมื่อต้องการดูว่า ``text`` อยู่ในข้อความของ toast
+    ...
+    ...    บางครั้ง error toast มีมากกว่า 1 ข้อความเช่นมี code อยู่ข้างล่าง
+    ...    โดยค่าเริ่มต้น ``result`` คือ 1 แปลว่าตรวจข้อความปกติของ toast
+    ...    สามารถใส่ ``result`` เป็น last() ได้ถ้าหากต้องการตรวจสอบข้อความจาก error code แทน
+    ...
+    ...    สามารถใส่ ``error`` ถ้าต้องการกำหนดข้อความ error เองเมื่อข้อความไม่ถูกต้อง
+    ...    keyword จะแทนที่ <TEXT> ด้วย ``text`` และแทนที่ <ACTUAL_TEXT> ด้วยข้อความของ toast
+    [Arguments]
+    ...    ${text}
+    ...    ${condition}=$text == $actual_text
+    ...    ${toast no}=1
+    ...    ${result}=1
+    ...    ${error}=Toast message: expected "<TEXT>", found "<ACTUAL_TEXT>"
+
+    ${actual_text}    Get Toast Text    ${toast no}    ${result}
+    IF  not (${condition})
+    ...    Fail    ${{ $error.replace("<TEXT>", $text).replace("<ACTUAL_TEXT>", $actual_text) }}

--- a/resources/FormUtility.resource
+++ b/resources/FormUtility.resource
@@ -369,7 +369,7 @@ Get Toast Status
     [Documentation]    คืนค่าสถานะของ toast อันที่ ``toast no``
     ...
     ...    ``toast no``=1 คือ toast ใหม่ล่าสุด
-    ...    ``toast no``=2 คือ toast ที่มาก่อนใหม่ล่าสุด
+    ...    ``toast no``=2 คือ toast ใหม่ลองลงมา
     ...
     ...    ค่าที่สามารถคืนได้คือ "SUCCESS", "FAIL", "LOADING" และ "UNKNOWN"
     ...    และคืนค่า ``None`` ถ้าไม่เจอ toast status

--- a/resources/ImportData.resource
+++ b/resources/ImportData.resource
@@ -64,7 +64,9 @@ Upload Evidence By Text
     # ${upload button}    Get WebElement
     Mouse Over     ${locator}/following-sibling::*
     Choose File    ${locator}    ${file_path}
-    Wait Until Element Is Visible    //div[@role="status" and text()='Evidence uploaded successfully']    ${timeout}
+    Wait Until Toast Finish Loading    ${timeout}
+    Toast Status Should Be    Successful
+    Toast Message Should Be    Evidence uploaded successfully
     Mouse Out      ${locator}/following-sibling::*
 
 Done Upload Evidence
@@ -83,6 +85,3 @@ Click Download Template
     Click Download Template Menu Button
     Click ${org} Menu Button
     Wait Until Page Contains    Downloading Template... 
-
-    
-    

--- a/resources/InputEmission.resource
+++ b/resources/InputEmission.resource
@@ -71,6 +71,14 @@ Click Delete Emission
     Wait Until Element Is Not Visible    //section
     Wait Until Page Does Not Contain    EM-${id}
 
+Save Emission As Draft
+    ${id}    Get Last Running No
+    Click Element    //button[.='Save as Draft']
+    Wait Until Toast Finish Loading
+    Toast Status Should Be    Successful
+    Toast Message Should Be    Emission created successfully
+    Wait Until New Running No Is Visible    ${id}
+
 Check Record Emission
     [Arguments]
     ...    ${scope 1}=${None}

--- a/resources/ReportTemplate.resource
+++ b/resources/ReportTemplate.resource
@@ -136,23 +136,31 @@ Click Edit Report
 Click Export Report
     Click Kebab Button In Table
     Click Export Menu Button
-    Wait Until Page Contains    Template exported successfully    10s
+    Wait Until Toast Finish Loading    10s
+    Toast Status Should Be    Successful
+    Toast Message Should Be    Template exported successfully
 
 Click Delete Report
     Click Kebab Button In Table
     Click Delete Menu Button
     Wait Until Element Is Visible    //button[.='Delete']
     Click Element    //button[.='Delete']
-    Wait Until Page Contains    Template deleted successfully
-    
+    Wait Until Toast Finish Loading
+    Toast Status Should Be    Successful
+    Toast Message Should Be    Template deleted successfully
+
 Click Save Report
     Click Element    //button[.='Save']
-    Wait Until Page Contains    The report template was successfully saved
+    Wait Until Toast Finish Loading
+    Toast Status Should Be    Successful
+    Toast Message Should Be    The report template was successfully saved
 
 Click Save & Report
     Click Element    //button[.='Save & Export']
-    Wait Until Page Contains    The report template was successfully saved
-    Wait Until Page Contains    Template exported successfully    10s
+    Wait Until Toast Finish Loading    timeout=1    toast no=2
+    Toast Status Should Be    Successful    toast no=2
+    Toast Message Should Be    The report template was successfully saved    toast no=2
+    Wait Until Toast Finish Loading    10
+    Toast Status Should Be    Successful
+    Toast Message Should Be    Template exported successfully
     Click Go Back To List Report
-
-


### PR DESCRIPTION
## 1. Keyword ใหม่
<h3 id="get-toast-status"><i>Get Toast Status</i></h3>
ก็ตามชื่อ keyword นี้จะคืนข้อความบอกสถานะของ toast ที่กำลังแสดงอยู่ ค่าที่จะสามารถคืนได้มีได้แก่

- `SUCCESS`: icon สถานะของ toast เป็นสีเขียว
- `FAIL`: icon สถานะของ toast เป็นสีแดง
- `LOADING`: icon สถานะของ toast กำลังหมุน
- `UNKNOWN`: เกิดข้อผิดพลาดกับการตรวจสอบ icon ของ toast (เช่นเกิดมี icon สีน้ำเงินโผล่ขึ้นมา)
- `None`: เป็นค่า `${None}` (ไม่ใช่ string) ถ้าเกิดว่าหา icon ของ toast ไม่เจอ เช่นตอนไม่มี toast

_Get Toast Status_ มี arguments 2 ตัวได้แก่ `toast no` และ `required`
- `toast no`: ลำดับความใหม่ของ toast โดย 1 คือใหม่สุด 2 คือใหม่ลองลงมา ไปเรื่อย ๆ ( last() คือเก่าที่สุด )
![image](https://github.com/Pinkporn/em-robot/assets/61837450/a00c8bd7-6f2f-413c-87f5-71007a3b209a)
จากรูปจะเป็นว่ามี toast อยู่ 2 อัน toast ที่กำลัง loading จะเป็นอันที่ 2 และ toast ที่ success แล้วจะเป็นอันที่ 2
```
${status}    Get Toast Status
# ${status} = "LOADING"
${status}    Get Toast Status    2
# ${status} = "SUCCESS"
```
- `required`: เป็น boolean (`${True}`/`${False}`) ถ้าจะใส่ค่าให้ `required` ต้องใส่ `required=` นำหน้า ([named argument](https://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#named-argument-syntax))
ถ้าเป็น `True` _Get Toast Status_ จะเกิด error เมื่อหา icon ของ toast ไม่เจอ ถ้าเป็น `False` จะคืนค่า `None`
ค่าเริ่มต้น `required` เป็น `False`

โดยปกติแล้วพี่พรน่าจะไม่ได้ใช้ keyword นี้ (เพราะเอาไปใช้ใน keyword อื่นถัดจากนี้)

<h3 id="get-toast-text"><i>Get Toast Text</i></h3>
คืนค่าข้อความของ toast

มี 2 arguments ได้แก่ `toast no` และ `result`
- `toast no`: ลำดับความใหม่ของ toast (เหมือนของ _Get Toast Status_)
- `result`: มีไว้เผื่อต้องการ error code ใน toast อย่างในรูปข้างล่าง (ค่าเริ่มต้นคือ 1)
![image](https://github.com/Pinkporn/em-robot/assets/61837450/2c483fe0-26e6-4928-bc64-ca4ee43b37c9)
```
${text}    Get Toast Text
# ${text} = "Start-Date-Or-End-Date-Overlapping"
${text}    Get Toast Text    result=last()
# ${text} = "code: 305"
```

<h3 id="wait-until-toast-finish-loading"><i>Wait Until Toast Finish Loading</i></h3>
รอจนกว่า toast อันที่ `toast no` จะเป็นสถานะอื่นที่ไม่ใช่ LOADING

มี 2 arguments ได้แก่ `timeout` และ `toast no`
- `timeout`: เวลานานที่สุดที่จะยอมรอ
- `toast no`: ลำดับความใหม่ของ toast (เหมือนของ _Get Toast Status_)

<h3 id="toast-status-should-be"><i>Toast Status Should Be</i></h3>
ตรวจสอบสถานะของ toast

มี 3 arguments ได้แก่ `status`, `error` และ `toast no`
- `status`: สถานะของ toast ที่ควรจะเป็น
ค่าที่ใส่ได้คือ "Successful", "Failed" และ "Loading"
จริงๆแล้วจะใส่เป็น "SUCCESS", "FAIL", "LOADING" หรือ "UNKNOWN" ก็ได้ แต่แนะนำให้ใส่ค่าแบบแรก เพื่อความเป็นภาษาคน
- `error`: ข้อความเมื่อ fail เผื่ออยากกำหนดข้อความเอง
keyword จะแทนที่ \<STATUS> ด้วย `status` แทนที่ <ACTUAL_STATUS> ด้วยสถานะที่พบของ toast และแทนที่ <ACTUAL_TEXT> ด้วยข้อความของ toast
![image](https://github.com/Pinkporn/em-robot/assets/61837450/2c483fe0-26e6-4928-bc64-ca4ee43b37c9)
```
Toast Status Should Be    Successful    error=I want "<STATUS>", but got "<ACTUAL_STATUS>" with "<ACTUAL_TEXT>"
# I want "SUCCESS", but got "FAIL" with "Start-Date-Or-End-Date-Overlapping"
```

<h3 id="toast-message-should-be"><i>Toast Message Should Be</i></h3>
ตรวจข้อความของ toast

มี 5 arguments ได้แก่ `text`, `condition`, `toast no`, `result` และ `error`
- `text`: ข้อความที่คาดหวัง
- `condition`: เงื่อนไข ค่าเริ่มต้นคือ `$text == $actual_text` แปลว่าข้อความต้องเหมือนกัน
- `toast no`: ลำดับความใหม่ของ toast (เหมือนของ _Get Toast Status_)
- `result`: argument `result` ของ _Get Toast Text_
- `error`: ข้อความเมื่อ fail เผื่ออยากกำหนดข้อความเอง
keyword จะแทนที่ \<TEXT> ด้วย ``text`` และแทนที่ <ACTUAL_TEXT> ด้วยข้อความของ toast

## 2. _Save Emission As Draft_
ปกติแล้วเวลาจะเพิ่ม emission ก็จะเขียน code ในลักษณะประมาณนี้
```
*** Test Cases ***
TC-01
    ${id}    Get Last Running No
    Add Emission Page 1 2    Gideon Two    Site OU    Fuel
    Enter Fuel Form    from date=Apr 2023    to date=May 2023    asset name=Bike OU-1
    ...    fuel=LPG_A (On-road vehicle)    publisher=EF A    amount=100
    Click Element    //button[.='Save as Draft']
    Wait Until Page Contains    Emission created successfully
    Wait Until New Running No Is Visible    ${id}
```
![image](https://github.com/Pinkporn/em-robot/assets/61837450/ff333ce9-f546-43d7-841c-83f812b0df46)
ถ้าเกิดว่า run test case TC-01 แล้วเกิด error แบบในรูปขึ้นมา จะมีปัญหาคือ
1. ต้องเสียเวลารอจนกว่าจะ timeout
โดยปกติแล้วก็จะเสียเวลารอ 5 วินาที แต่ถ้าตั้ง timeout นานกว่านั้น ก็ต้องรอนานขึ้นอีก
2. ข้อความ error ที่ขึ้นใน console ไม่ค่อยมีประโยชน์
อย่างกรณีในรูปข้างต้นก็จะมีข้อความประมาณว่า `Text 'Emission created successfully' did not appear in 5 seconds.` ซึ่งก็ทำให้รู้แหละว่าสร้างไม่สำเร็จ แต่เราไม่รู้ว่าสร้างไม่สำเร็จเพราะยังโหลดไม่เสร็จหรือล้มเหลว แล้วถ้าล้มเหลว มีข้อความว่าอะไร
3. ถ้า toast เก่ายังอยู่ _Wait Until Page Contains_ ก็จะไม่มีประโยชน์ เพราะ _Wait Until Page Contains_ ดูแค่ว่ามีข้อความอยู่หรือไม่ ไม่ได้ดูข้อความของ toast ใหม่ที่พึ่งโผล่ขึ้นมา

เพื่อแก้ปัญหาที่ว่ามาทั้งหมดนี้ จึงจะเปลี่ยน _Wait Until Page Contains_ ให้ไปใช้ keyword ใหม่แทน
```
*** Keywords ***
Save Emission As Draft
    ${id}    Get Last Running No
    Click Element    //button[.='Save as Draft']
    Wait Until Toast Finish Loading                             # <-
    Toast Status Should Be    Successful                        # <-
    Toast Message Should Be    Emission created successfully    # <-
    Wait Until New Running No Is Visible    ${id}

*** Test Cases ***
TC-01
    Add Emission Page 1 2    Gideon Two    Site OU    Fuel
    Enter Fuel Form    from date=Apr 2023    to date=May 2023    asset name=Bike OU-1
    ...    fuel=LPG_A (On-road vehicle)    publisher=EF A    amount=100
    Save Emission As Draft
```
`${id}    Get Last Running No` ไม่จำเป็นต้องอยู่หน้า _Add Emission Page 1 2_ เลยย้ายมาไว้ก่อน Save as Draft
จากนั้นแทนที่ _Wait Until Page Contains_ ด้วย
```
Wait Until Toast Finish Loading
Toast Status Should Be    Successful
Toast Message Should Be    Emission created successfully
```
จริง ๆ แล้ว _Toast Message Should Be_ ไม่จำเป็นสักเท่าไหร่ เพราะยังไงหลัก ๆ เราก็สนแค่ toast เป็น success เท่านั้น

พอแทนที่เสร็จ ก็นำไปสร้าง keyword _Save Emission As Draft_
ทำให้พอเพิ่ม emission หรือทำอะไรไม่สำเร็จก็จะมีข้อความบอก
`Toast status: expected "SUCCESS", found "FAIL" with message "Something went wrong. Please try again later."`

Update
- _Save Emission As Draft_ ถูกเพิ่มไปใน InputEmission.resource ให้แล้ว กรุณานำไปใช้

- _Save Emission As Draft_ ถูกแก้เป็น _Save Emission_ ที่มีชื่อปุ่มเป็น argument

## 3. แก้ bug
แก้ bug ที่เวลาใช้ _Wait Until New Running No Is Visible_ หากใส่ timeout จะเกิด error
`TypeError: unsupported operand type(s) for +: 'float' and 'str'`
เหตุผลที่เกิด error เพราะลืมแปลง timeout ให้เป็น float

## 4. แก้ไขให้ keyword ใช้ของใหม่
หลังจากสร้าง _Save Emission As Draft_ ก็แก้ให้ TestInput ทั้งหลายมาใช้ _Save Emission As Draft_

เปลี่ยนพวก _Wait Until Page Contains_ ให้มาใช้ keyword ใหม่

## 5. อธิบายการหาสถานะของ toast
นี่คือ xpath สำหรับการหา icon ของ toast
```
((//div[@role='status'])[1]/..//div[not(node())])[last()]
```
สมมุติว่าเรา Save แล้ว Export ในหน้า Report Template

![image](https://github.com/Pinkporn/em-robot/assets/61837450/a00c8bd7-6f2f-413c-87f5-71007a3b209a)
จะได้โครงสร้าง element ในลักษณะนี้
```
<div style="position: fixed; z-index: 9999; ..." class="">
    <div class="go4109123758" style="left: 0px; right: 0px; ...">
        <div class="go2072408551" style="padding: 16px; ... go2645569136;">    <!-- A1 -->
            <div class="go685806154">
                <div class="go1858758034"></div>                               <!-- B1 -->
            </div>
            <div role="status" aria-live="polite" class="go3958317564">        <!-- D1 -->
                Exporting template...
            </div>
        </div>
    </div>
    <div class="go4109123758" style="left: 0px; right: 0px; ...">
        <div class="go2072408551" style="padding: 16px; ... go2645569136;">    <!-- A2 -->
            <div class="go685806154">
                <div class="go1858758034"></div>                               <!-- B2 -->
                <div class="go1579819456">
                    <div class="go2344853693">                                 <!-- C2 -->
                        ::after
                    </div>
                </div>
            </div>
            <div role="status" aria-live="polite" class="go3958317564">        <!-- D2 -->
                The report template was successfully saved
            </div>
        </div>
    </div>
</div>
```
ดูจาก D1 และ D2 จะสังเกตเห็นว่า action ที่มาทีหลังจะอยู่ข้างบน (ในมุมมองของ html / DOM)
สมมุติว่าต้องการดู icon ของ toast "Exporting template" ดังนั้น B1 คือสิ่งที่เราต้องการ จึงได้ใช้ `//div[not(node())]` หา div ที่ไม่มีอะไรอยู่ข้างในจะทำให้ได้ B1 B2 C2 เราจึงจะใช้ `//div[@role='status']` ในการช่วยหา ในเมื่อเราต้องการ toast แรก จะทำให้ได้ `(//div[@role='status'])[1]` อยู่ที่ D1 ใช้ `/..` ออกมา 1 ชั้น มาอยู่ที่ A1 แล้วต่อด้วย `//div[not(node())]` ก็จะทำให้เรามาอยู่ที่ B1 แต่สังเกตว่าใน toast ที่ 2 มี B2 และ C2 โดย B2 คือไอที่หมุนๆ และ C2 คือเครื่องหมายติ๊กถูก (หรือก็คือเครื่องหมายติ๊กถูกมีไอที่หมุนๆซ่อนอยู่ข้างหลัง และเครื่องหมายกากบาทบางครั้งก็เป็นเหมือนกัน) แปลว่าถ้าใช้ xpath ตอนนี้ จะหาเครื่องหมายติ๊กถูก (และกากบาท) ไม่ได้ จึงครอบ `(...)[last()]` เข้าไป ทำให้สรุปได้ดังนี้
1. `//div[@role='status']`
2. `(//div[@role='status'])[1]`
3. `(//div[@role='status'])[1]/..`
4. `(//div[@role='status'])[1]/..//div[not(node())]`
5. `((//div[@role='status'])[1]/..//div[not(node())])[last()]`
ตอนนี้คือเจอ icon สถานะแล้ว แต่มันยังไม่จบเพราะต้องแยกประเภท icon ต่อ โดยวิธีแยกก็คือดูจากสี อ่านค่าสีจาก css
- สี background ของเครื่องหมายติ๊กถูกคือ `rgba(97, 211, 69, 1)`
- สี background ของเครื่องหมายกากบาทคือ `rgba(255, 75, 75, 1)`
- ส่วน loading icon ไม่มีสี background `rgba(0, 0, 0, 0)`

ดังนั้นเงื่อนไขที่เช็คก็คือ
- ค่าสีเขียวมากสุด เป็น success
- ค่าสีแดงมากสุด เป็น fail
- ไม่มีสี alpha=0 เป็น loading